### PR TITLE
Add symbolAs as an parseOption.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4375,8 +4375,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -5,6 +5,7 @@ export interface ParseOptions {
   setAs?: 'object' | 'array' | 'set';
   listAs?: 'object' | 'array';
   keywordAs?: 'object' | 'string';
+  symbolAs?: 'object' | 'string';
   charAs?: 'object' | 'string';
   tagHandlers?: { [tag: string]: (val: unknown) => unknown };
   objectKeysAs?: 'object' | 'string'
@@ -55,6 +56,7 @@ export class EDNListParser {
   mapAs: ParseOptions['mapAs'];
   setAs: ParseOptions['setAs'];
   keywordAs: ParseOptions['keywordAs'];
+  symbolAs: ParseOptions['charAs'];
   charAs: ParseOptions['charAs'];
   listAs: ParseOptions['listAs'];
   tagHandlers: ParseOptions['tagHandlers'];
@@ -64,6 +66,7 @@ export class EDNListParser {
     mapAs = 'doubleArray',
     setAs = 'object',
     keywordAs = 'object',
+    symbolAs = 'object',
     charAs = 'object',
     listAs = 'object',
     tagHandlers = {},
@@ -72,6 +75,7 @@ export class EDNListParser {
     this.mapAs = mapAs;
     this.setAs = setAs;
     this.keywordAs = keywordAs;
+    this.symbolAs = symbolAs;
     this.charAs = charAs;
     this.listAs = listAs;
     this.objectKeysAs = objectKeysAs;
@@ -165,7 +169,11 @@ export class EDNListParser {
       }
     } else if (this.state !== '') {
       // Symbol
-      this.result = { sym: this.state };
+      if (this.symbolAs === 'string') {
+        this.result = this.state;
+      } else {
+        this.result = { sym: this.state };
+      }
     }
     this.state = '';
   }

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -607,6 +607,19 @@ test('readme exsample', (t) => {
   );
 });
 
+test('symbols as strings', (t) => {
+  t.deepEqual(
+    parseEDNString('{:some datum}', {
+      mapAs: 'object',
+      symbolAs: 'string',
+      keywordAs: 'string'
+    }),
+    {
+      some: "datum"
+    }
+  )
+});
+
 test('objectKeys as string', (t) => {
   t.deepEqual(
     parseEDNString('{[407 {:someKey "lovely-value"}] #{123}}', {


### PR DESCRIPTION
This allows symbols to be treated like keywords.