### PR TITLE
Parse \uNNNN and \b/\f escapes in strings and characters

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -15,6 +15,7 @@ enum ParseMode {
   idle,
   string,
   escape,
+  unicode,
   comment,
 }
 enum StackItem {
@@ -28,10 +29,14 @@ const stringEscapeMap = {
   t: '\t',
   r: '\r',
   n: '\n',
+  b: '\b',
+  f: '\f',
   '\\': '\\',
   '"': '"',
 };
 const spaceChars = [',', ' ', '\t', '\n', '\r'];
+const hexRegex = /^[0-9a-fA-F]$/;
+const charUnicodeRegex = /^\\u[0-9a-fA-F]{4}$/;
 const intRegex = /^[-+]?(0|[1-9][0-9]*)$/;
 const bigintRegex = /^[-+]?(0|[1-9][0-9]*)N$/;
 const floatRegex =
@@ -160,6 +165,9 @@ export class EDNListParser {
         c = '	';
       } else if (this.state === '\\\\') {
         c = '\\';
+      } else if (charUnicodeRegex.test(this.state)) {
+        // \uNNNN character literal (#3)
+        c = String.fromCharCode(parseInt(this.state.slice(2), 16));
       } else {
         c = this.state.substr(1);
       }
@@ -350,11 +358,30 @@ export class EDNListParser {
         }
         this.state += char;
       } else if (this.mode === ParseMode.escape) {
-        // TODO what should happen when escaping other char
+        if (char === 'u') {
+          // \uNNNN: collect the 4 hex digits, which may span stream chunks
+          this.mode = ParseMode.unicode;
+          this.state = '';
+          continue;
+        }
         const escapedChar = stringEscapeMap[char];
+        if (escapedChar === undefined) {
+          throw new Error(`Unexpected escape character: \\${char}`);
+        }
         const [stackItem, prevState] = this.stack.pop();
         this.mode = stackItem;
         this.state = prevState + escapedChar;
+      } else if (this.mode === ParseMode.unicode) {
+        if (!hexRegex.test(char)) {
+          throw new Error(`Invalid unicode escape: \\u${this.state}${char}`);
+        }
+        this.state += char;
+        if (this.state.length === 4) {
+          const codePoint = parseInt(this.state, 16);
+          const [stackItem, prevState] = this.stack.pop();
+          this.mode = stackItem;
+          this.state = prevState + String.fromCharCode(codePoint);
+        }
       } else if (this.mode === ParseMode.comment) {
         if (char === '\n') {
           this.mode = ParseMode.idle;

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { EDNVal, parseEDNString } from '../src';
+import { EDNVal, parseEDNString, toEDNString } from '../src';
 
 test('empty document as null', (t) => {
   t.is(parseEDNString(''), null);
@@ -33,6 +33,42 @@ test('string with backslash', (t) => {
 });
 test('string with quote symbol', (t) => {
   t.is(parseEDNString('"\\""'), '"');
+});
+test('string with backspace', (t) => {
+  t.is(parseEDNString('"one\\btwo"'), 'one\btwo');
+});
+test('string with form feed', (t) => {
+  t.is(parseEDNString('"one\\ftwo"'), 'one\ftwo');
+});
+test('string with unicode escape', (t) => {
+  t.is(parseEDNString('"\\u0041"'), 'A');
+});
+test('string with non-ascii unicode escape', (t) => {
+  t.is(parseEDNString('"a\\u00e9b"'), 'aéb');
+});
+test('string with unicode escape spanning tokens', (t) => {
+  t.is(parseEDNString('"\\u26a1zap"'), '⚡zap');
+});
+test('unknown string escape throws', (t) => {
+  t.throws(() => parseEDNString('"a\\xb"'));
+});
+test('incomplete unicode escape throws', (t) => {
+  t.throws(() => parseEDNString('"a\\u00gz"'));
+});
+test('string escapes round-trip through toEDNString', (t) => {
+  // toEDNString emits \b \f \n \r \t and \uNNNN (via JSON.stringify); the
+  // parser must read every one of them back (#3).
+  for (let code = 0; code < 0x20; code++) {
+    const s = String.fromCharCode(code);
+    t.is(
+      parseEDNString(toEDNString(s)),
+      s,
+      `control char 0x${code.toString(16)}`,
+    );
+  }
+  for (const s of ['"', '\\', 'aéb', '⚡', 'tab\tnewline\n']) {
+    t.is(parseEDNString(toEDNString(s)), s);
+  }
 });
 test('string after symbol without space', (t) => {
   t.deepEqual(parseEDNString('[hi"hi"]'), [{ sym: 'hi' }, 'hi']);
@@ -79,6 +115,15 @@ test('char backslash', (t) => {
 });
 test('char as string', (t) => {
   t.deepEqual(parseEDNString('\\abc', { charAs: 'string' }), 'abc');
+});
+test('char unicode', (t) => {
+  t.deepEqual(parseEDNString('\\u0041'), { char: 'A' });
+});
+test('char unicode non-ascii', (t) => {
+  t.deepEqual(parseEDNString('\\u00e9'), { char: 'é' });
+});
+test('char unicode as string', (t) => {
+  t.deepEqual(parseEDNString('\\u26a1', { charAs: 'string' }), '⚡');
 });
 
 test('int', (t) => {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -36,3 +36,11 @@ test('readme example', (t) => {
   t.deepEqual(s.read(), 2);
   t.deepEqual(s.read(), 3);
 });
+
+test('unicode escape split across chunks', (t) => {
+  const s = parseEDNListStream();
+  s.write('("a\\u');
+  s.write('00');
+  s.write('e9b")');
+  t.deepEqual(s.read(), 'aéb');
+});


### PR DESCRIPTION
Fixes #3.

`parseEDNString` corrupts `\uNNNN` and a couple of other escapes.

The string escape handler only knows `\t \r \n \\ \"`; any other escape looks up `undefined` in the escape map and splices the literal text `undefined` into the string, so `\uNNNN` is never decoded. Character literals have the mirror gap — `\uNNNN` falls through to `state.substr(1)` and comes back as the raw text.

```js
parseEDNString('"\\u0041"')                  // "undefined0041"   (want "A")
parseEDNString('"a\\u00e9b"')                // "aundefined00e9b" (want "aéb")
parseEDNString('\\u0041', {charAs:'string'}) // "u0041"           (want "A")
```

It's also a round-trip bug against this library's own generator: `toEDNString` goes through `JSON.stringify`, which emits `\b`/`\f` for U+0008/U+000C and `\uNNNN` for the other control characters — none of which the parser could read back, so `parseEDNString(toEDNString(s)) !== s` for any string containing a control character other than tab/newline/return.

Fix is all on the parse side (smaller than changing the generator, and it also lets the parser read real Clojure-produced EDN):

- decode `\uNNNN` in both the string and char paths; the four hex digits are accumulated in a sub-state so they survive a stream chunk boundary instead of being sliced from a lookahead
- add `\b`/`\f` to the escape map so the generator's output round-trips
- throw on an unrecognised escape instead of silently writing `undefined`

Tests cover `\uNNNN` (string + char, incl. non-ASCII), `\b`/`\f`, a chunk-split case in the stream parser, throw-on-invalid-escape, and a round-trip property test over U+0000–U+001F. `npm test` goes from 148 to 160 passing.

Left out, can follow up if useful: emitting control characters *inside* char literals on the generate side (`toEDNString({char:'\n'})` currently writes a bare backslash + newline), and octal char escapes.
